### PR TITLE
Fixes for micha_reader and bond_analysis

### DIFF
--- a/src/oxDNA_analysis_tools/UTILS/micha_reader.py
+++ b/src/oxDNA_analysis_tools/UTILS/micha_reader.py
@@ -92,8 +92,13 @@ class MichaReader:
 
         #get the topology file info 
         with open(top) as f:
-            nbases, nstrands = f.readline().split(' ')
+            my_top_info = f.readline().split(' ')
+            if len(my_top_info)  == 2:
+                nbases, nstrands = my_top_info
+            elif len(my_top_info) == 5:
+                nbases, nstrands, ndna, nres, ndnastrands = my_top_info
             self.top_info = TopInfo(int(nbases), int(nstrands))
+
         
         #open trajectory file
         self.traj_file = open(traj_file, 'r')

--- a/src/oxDNA_analysis_tools/bond_analysis.py
+++ b/src/oxDNA_analysis_tools/bond_analysis.py
@@ -130,7 +130,7 @@ def main():
         r = LorenzoReader2(traj_file,top_file)
         tot_bonds, tot_missbonds, out_array, confid = bond_analysis(r, pairs, inputfile, num_confs)
         try:
-            _ = tot_bonds[0] #this will fail if DNAnalysis failed.
+            _ = tot_bonds #this will fail if DNAnalysis failed.
         except:
             print("ERROR: DNAnalysis encountered an error and could not analyze the trajectory")
             exit(1)


### PR DESCRIPTION
The change to micha_reader allows it to work with the anm model (the first line of a top file for anm is different for a system with a protein). The bond analysis script did not work with a single core because tot_bonds is an integer, not a list.